### PR TITLE
fix: guard prerelease NuGet publish when API key is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,14 @@ jobs:
 
       - name: Publish prerelease to NuGet
         if: github.event_name == 'pull_request'
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -n "$NUGET_API_KEY" ]; then
+            dotnet nuget push ./nupkg/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          else
+            echo "NUGET_API_KEY not available, skipping prerelease publish"
+          fi
 
       - name: Create GitHub Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Dependabot PRs cannot access repository secrets, causing the prerelease publish step to fail with `error: Source parameter was not specified.`

This fix checks for `NUGET_API_KEY` before attempting push, so Dependabot PRs pass CI cleanly.