### PR TITLE
ci: auto-tag and create GitHub Release on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main
@@ -96,7 +94,7 @@ jobs:
           path: ./nupkg/*.nupkg
 
       - name: Publish to NuGet
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Publish prerelease to NuGet
@@ -110,9 +108,17 @@ jobs:
             echo "NUGET_API_KEY not available, skipping prerelease publish"
           fi
 
+      - name: Create tag
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git tag "v${{ steps.version.outputs.semVer }}"
+          git push origin "v${{ steps.version.outputs.semVer }}"
+
       - name: Create GitHub Release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.version.outputs.semVer }}
+          name: v${{ steps.version.outputs.semVer }}
           generate_release_notes: true
           files: ./nupkg/*.nupkg


### PR DESCRIPTION
## Changes

- **Remove `tags: v*` trigger** — tags are now created by CI itself, so this avoids infinite re-trigger loops
- **Add "Create tag" step** — pushes `v{semVer}` tag after successful NuGet publish on main
- **Update "Create GitHub Release" step** — triggers on main push (not tag push), uses auto-generated release notes via `release.yml` categories, attaches `.nupkg` artifact
- **Guard prerelease NuGet publish** — checks for `NUGET_API_KEY` availability before pushing (fixes Dependabot PR failures, supersedes #8)
- **Simplify NuGet publish condition** — main-only (tags no longer trigger CI)

## Flow after merge
`push to main → build → test → pack → publish to NuGet → create tag v{semVer} → create GitHub Release with notes + nupkg`

Closes #8