### PR TITLE
docs: fix Blazor example code block rendering

### DIFF
--- a/docs/articles/example-blazor-form.md
+++ b/docs/articles/example-blazor-form.md
@@ -2,9 +2,9 @@
 
 This example shows how to use `Validation` in a Blazor component to validate a user creation form, displaying accumulated field errors inline.
 
-## The Form Component
+## The Form Component (`CreateUser.razor`)
 
-```razor
+```html
 @page "/users/create"
 @using DarkPeak.Functional
 @using DarkPeak.Functional.Extensions
@@ -62,11 +62,7 @@ This example shows how to use `Validation` in a Blazor component to validate a u
         <div class="alert alert-danger mt-3">@_generalError</div>
     }
 </EditForm>
-```
 
-## The Code-Behind
-
-```razor
 @code {
     [Inject] private IUserService UserService { get; set; } = default!;
 


### PR DESCRIPTION
The Blazor example code blocks were rendering as plain text because DocFX's highlight.js does not support `razor` as a language identifier.

**Fix:** Merged the form template and code-behind into a single `html`-fenced code block (matching how a real `.razor` file looks), which highlight.js renders properly with code block styling.