### PR TITLE
feat: add circuit breaker, MemoizeResult, move Unit to core, and enhance Http extensions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,11 @@ All three packages are versioned together and released simultaneously via the ma
 - **`Validation<T, TError>`** — Accumulates multiple errors instead of short-circuiting. Implementations: `Valid<T, TError>`, `Invalid<T, TError>`
 - **`Error`** — Abstract base record for typed errors with HTTP-mapped subtypes (ValidationError, NotFoundError, UnauthorizedError, etc.)
 - **`RetryPolicy`** — Configurable retry with backoff strategies (None, Constant, Linear, Exponential). Entry point: `Retry.WithMaxAttempts()`
+- **`CircuitBreakerPolicy`** — Circuit breaker that tracks consecutive failures and transitions between Closed, Open, and HalfOpen states to prevent cascading failures. Entry point: `CircuitBreaker.WithFailureThreshold()`. Uses a shared `CircuitBreakerStateTracker` for mutable state with `Lock`-based thread safety.
+- **`CircuitBreakerOpenError`** — Error returned when the circuit is open, with a `RetryAfter` property indicating time until half-open.
 - **`Memoize`** — Function caching with TTL, LRU eviction, and pluggable distributed cache via `ICacheProvider<TKey, TValue>`
+- **`MemoizeResult`** — Function caching for `Result<T, TError>`-returning functions that only caches successful results. Failed results pass through uncached so subsequent calls retry the computation. Entry point: `MemoizeResult.Func()` / `MemoizeResult.FuncAsync()`
+- **`Unit`** — Valueless type representing a successful operation with no return value. Located in the core `DarkPeak.Functional` namespace.
 
 ### HTTP Client Extensions (DarkPeak.Functional.Http)
 
@@ -76,9 +80,13 @@ All three packages are versioned together and released simultaneously via the ma
   - `DeleteResultAsync<T>()` — DELETE with JSON response body
   - `SendResultAsync<T>()` — Custom `HttpRequestMessage` with JSON response
   - `SendResultAsync()` — Custom `HttpRequestMessage` without response body
+  - `GetStringResultAsync()` — GET returning `Result<string, Error>` for plain text/XML/HTML
+  - `GetStreamResultAsync()` — GET returning `Result<Stream, Error>` with `ResponseHeadersRead` for streaming
+  - `GetBytesResultAsync()` — GET returning `Result<byte[], Error>` for binary data
+  - All methods above (except `SendResultAsync`) have an overload accepting `Action<HttpRequestMessage> configure` for per-request header/auth customization
 - **`HttpError`** — Error type for HTTP responses with `StatusCode`, `ReasonPhrase`, `ResponseBody`
 - **`HttpRequestError`** — Error type for transport-level failures (network errors, timeouts)
-- **`Unit`** — Valueless success type for operations without a response body
+- **`Unit`** — Now located in the core `DarkPeak.Functional` namespace (moved from Http)
 - **Status code mapping**: 400→BadRequestError, 401→UnauthorizedError, 403→ForbiddenError, 404→NotFoundError, 409→ConflictError, 422→ValidationError, 5xx→ExternalServiceError, other→HttpError
 
 ### ASP.NET Integration (DarkPeak.Functional.AspNet)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A functional programming library for .NET providing monadic types and railway-or
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| **DarkPeak.Functional** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.svg)](https://www.nuget.org/packages/DarkPeak.Functional/) | Core library providing monadic types (`Option`, `Result`, `Either`, `Validation`), retry policies with backoff strategies, and memoization with TTL/LRU support. |
-| **DarkPeak.Functional.Http** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.Http.svg)](https://www.nuget.org/packages/DarkPeak.Functional.Http/) | Wraps `HttpClient` operations in `Result<T, Error>` for type-safe, exception-free HTTP communication. |
+| **DarkPeak.Functional** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.svg)](https://www.nuget.org/packages/DarkPeak.Functional/) | Core library providing monadic types (`Option`, `Result`, `Either`, `Validation`), retry policies with backoff strategies, circuit breaker, memoization with TTL/LRU support, and `MemoizeResult` for caching only successful `Result` values. |
+| **DarkPeak.Functional.Http** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.Http.svg)](https://www.nuget.org/packages/DarkPeak.Functional.Http/) | Wraps `HttpClient` operations in `Result<T, Error>` for type-safe, exception-free HTTP communication. Supports JSON, string, stream, and byte array responses with per-request header customization. |
 | **DarkPeak.Functional.AspNet** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.AspNet.svg)](https://www.nuget.org/packages/DarkPeak.Functional.AspNet/) | ASP.NET integration that converts `Result<T, Error>` to `IResult` and `ProblemDetails` for idiomatic minimal API error handling. |
 
 All types support `Map`, `Bind`, `Match`, LINQ query syntax, and async variants.

--- a/docs/articles/circuit-breaker.md
+++ b/docs/articles/circuit-breaker.md
@@ -1,0 +1,159 @@
+# Circuit Breaker
+
+The `CircuitBreaker` module prevents cascading failures by short-circuiting requests to a failing dependency. It integrates with `Result<T, TError>` — the circuit tracks failures and rejects requests when a threshold is reached.
+
+## Basic Usage
+
+```csharp
+var breaker = CircuitBreaker.WithFailureThreshold(5)
+    .WithResetTimeout(TimeSpan.FromSeconds(30));
+
+var result = breaker.Execute(() => CallExternalService());
+// After 5 consecutive failures, subsequent calls return CircuitBreakerOpenError immediately
+```
+
+## Builder API
+
+Build circuit breaker policies fluently:
+
+```csharp
+var breaker = CircuitBreaker
+    .WithFailureThreshold(5)
+    .WithResetTimeout(TimeSpan.FromSeconds(30))
+    .WithBreakWhen(error => error is ExternalServiceError)
+    .OnStateChange((from, to) =>
+        logger.LogWarning("Circuit breaker: {From} -> {To}", from, to));
+
+var result = await breaker.ExecuteAsync(
+    () => httpClient.GetResultAsync<Data>("/api/data"));
+```
+
+### Policy Options
+
+| Method | Description |
+|--------|-------------|
+| `WithFailureThreshold(int)` | Consecutive failures before the circuit opens (at least 1) |
+| `WithResetTimeout(TimeSpan)` | Duration the circuit stays open before transitioning to half-open |
+| `WithBreakWhen(Func<Error, bool>)` | Predicate to filter which errors count toward the threshold |
+| `OnStateChange(Action<CircuitBreakerState, CircuitBreakerState>)` | Callback for logging/observability on state transitions |
+
+## State Transitions
+
+The circuit breaker has three states:
+
+```
+  ┌──────────┐  failure threshold   ┌──────┐  reset timeout   ┌──────────┐
+  │  Closed  │ ────────────────────> │ Open │ ────────────────> │ HalfOpen │
+  └──────────┘                      └──────┘                   └──────────┘
+       ^                                ^                           │
+       │                                │                           │
+       │          success               │        failure            │
+       └────────────────────────────────┴───────────────────────────┘
+```
+
+- **Closed** — Normal operation. Failures increment a counter. When the counter reaches the failure threshold, the circuit opens.
+- **Open** — All requests are immediately rejected with `CircuitBreakerOpenError`. After the reset timeout elapses, the circuit transitions to half-open.
+- **HalfOpen** — One probe request is allowed through. On success the circuit closes and the failure counter resets; on failure it reopens.
+
+## Sync and Async
+
+Both synchronous and asynchronous execution are supported:
+
+```csharp
+// Synchronous
+Result<Data, Error> result = breaker.Execute(() => LoadData());
+
+// Asynchronous
+Result<Data, Error> result = await breaker.ExecuteAsync(() => LoadDataAsync());
+```
+
+## Selective Breaking
+
+Only count specific error types toward the failure threshold:
+
+```csharp
+var breaker = CircuitBreaker.WithFailureThreshold(3)
+    .WithBreakWhen(error => error is ExternalServiceError);
+
+// ValidationError or NotFoundError will NOT trip the breaker
+var result = await breaker.ExecuteAsync(() => CallServiceAsync());
+```
+
+## The Open Error
+
+When the circuit is open, `CircuitBreakerOpenError` is returned with a `RetryAfter` property indicating when the circuit will transition to half-open:
+
+```csharp
+var result = await breaker.ExecuteAsync(() => CallServiceAsync());
+
+result.TapError(error =>
+{
+    if (error is CircuitBreakerOpenError openError)
+    {
+        logger.LogWarning(
+            "Circuit open, retry after {RetryAfter}",
+            openError.RetryAfter);
+    }
+});
+```
+
+## Observability
+
+Monitor state transitions for logging, metrics, or alerting:
+
+```csharp
+var breaker = CircuitBreaker
+    .WithFailureThreshold(5)
+    .WithResetTimeout(TimeSpan.FromSeconds(30))
+    .OnStateChange((from, to) =>
+    {
+        logger.LogWarning("Circuit breaker: {From} -> {To}", from, to);
+        metrics.RecordCircuitStateChange(from, to);
+    });
+```
+
+## Thread Safety
+
+The circuit breaker is thread-safe. The policy configuration is immutable, while the internal state (failure count, current state, timestamps) is managed by a shared state tracker protected by a `Lock`. A single `CircuitBreakerPolicy` instance can be safely shared across multiple threads and concurrent calls to `Execute`/`ExecuteAsync`.
+
+## Composition with Retry
+
+Combine circuit breaker with retry for resilient service calls. Place the circuit breaker **inside** the retry so that open-circuit rejections are retried after the timeout:
+
+```csharp
+var breaker = CircuitBreaker
+    .WithFailureThreshold(3)
+    .WithResetTimeout(TimeSpan.FromSeconds(30))
+    .WithBreakWhen(error => error is ExternalServiceError);
+
+var result = await Retry
+    .WithMaxAttempts(5)
+    .WithBackoff(Backoff.Exponential(TimeSpan.FromMilliseconds(500)))
+    .WithRetryWhen(error => error is ExternalServiceError or CircuitBreakerOpenError)
+    .OnRetry((attempt, error) =>
+        logger.LogWarning("Attempt {Attempt}: {Error}", attempt, error.Message))
+    .ExecuteAsync(() =>
+        breaker.ExecuteAsync(
+            () => httpClient.GetResultAsync<Data>("/api/data")));
+```
+
+## Composition with Http and MemoizeResult
+
+Build a full resilience stack with caching, circuit breaking, and retry:
+
+```csharp
+// Cache successful responses for 5 minutes
+var cachedFetch = MemoizeResult.FuncAsync<string, Data, Error>(
+    endpoint => Retry
+        .WithMaxAttempts(3)
+        .WithBackoff(Backoff.Exponential(TimeSpan.FromMilliseconds(200)))
+        .ExecuteAsync(() =>
+            breaker.ExecuteAsync(
+                () => httpClient.GetResultAsync<Data>(endpoint))),
+    opts => opts.WithExpiration(TimeSpan.FromMinutes(5)));
+
+var result = await cachedFetch("/api/data");
+// First call: cache miss → retry with circuit breaker → HTTP call
+// Subsequent calls within 5 min: cache hit (if first call succeeded)
+// If dependency is down: circuit opens after 3 failures, retries back off
+```

--- a/docs/articles/http.md
+++ b/docs/articles/http.md
@@ -1,0 +1,276 @@
+# Http
+
+The `DarkPeak.Functional.Http` package wraps `HttpClient` operations in `Result<T, Error>`, enabling railway-oriented HTTP communication without try/catch blocks.
+
+## Installation
+
+```bash
+dotnet add package DarkPeak.Functional.Http
+```
+
+## Basic Usage
+
+```csharp
+using DarkPeak.Functional;
+using DarkPeak.Functional.Http;
+
+var result = await httpClient.GetResultAsync<Order>("/api/orders/123");
+
+var message = result.Match(
+    success: order => $"Order {order.Id} totals {order.Total:C}",
+    failure: error => $"Failed: {error.Message}");
+```
+
+## JSON Methods
+
+All JSON methods deserialize the response body using `System.Text.Json`:
+
+```csharp
+// GET
+var order = await httpClient.GetResultAsync<Order>("/api/orders/123");
+
+// POST
+var created = await httpClient.PostResultAsync<Order>("/api/orders", newOrder);
+
+// PUT
+var updated = await httpClient.PutResultAsync<Order>("/api/orders/123", changes);
+
+// PATCH
+var patched = await httpClient.PatchResultAsync<Order>("/api/orders/123", patch);
+
+// DELETE (no response body)
+var deleted = await httpClient.DeleteResultAsync("/api/orders/123");
+
+// DELETE (with response body)
+var confirmation = await httpClient.DeleteResultAsync<DeletionResult>("/api/orders/123");
+
+// Custom request
+var request = new HttpRequestMessage(HttpMethod.Options, "/api/orders");
+var options = await httpClient.SendResultAsync<OptionsResponse>(request);
+
+// Custom request (no response body)
+var head = new HttpRequestMessage(HttpMethod.Head, "/api/health");
+var health = await httpClient.SendResultAsync(head);
+```
+
+### Custom JSON Options
+
+All JSON methods accept optional `JsonSerializerOptions`:
+
+```csharp
+var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+var result = await httpClient.GetResultAsync<Order>("/api/orders/123", options);
+```
+
+## Non-JSON Response Types
+
+For responses that are not JSON, use the typed GET methods:
+
+```csharp
+// String — plain text, XML, HTML
+var html = await httpClient.GetStringResultAsync("/api/reports/summary");
+
+// Stream — large files, binary data (uses ResponseHeadersRead for streaming)
+var stream = await httpClient.GetStreamResultAsync("/api/exports/report.csv");
+
+// Bytes — images, files, binary content
+var image = await httpClient.GetBytesResultAsync("/api/images/logo.png");
+```
+
+The stream variant uses `HttpCompletionOption.ResponseHeadersRead` so the response body is not buffered — the caller is responsible for disposing the returned `Stream`.
+
+### API Reference
+
+| Method | Return Type | Use Case |
+|--------|-------------|----------|
+| `GetResultAsync<T>` | `Result<T, Error>` | JSON deserialization |
+| `PostResultAsync<T>` | `Result<T, Error>` | JSON POST with response |
+| `PutResultAsync<T>` | `Result<T, Error>` | JSON PUT with response |
+| `PatchResultAsync<T>` | `Result<T, Error>` | JSON PATCH with response |
+| `DeleteResultAsync` | `Result<Unit, Error>` | DELETE without body |
+| `DeleteResultAsync<T>` | `Result<T, Error>` | DELETE with JSON response |
+| `SendResultAsync<T>` | `Result<T, Error>` | Custom request, JSON response |
+| `SendResultAsync` | `Result<Unit, Error>` | Custom request, no body |
+| `GetStringResultAsync` | `Result<string, Error>` | Plain text / XML / HTML |
+| `GetStreamResultAsync` | `Result<Stream, Error>` | Streaming binary data |
+| `GetBytesResultAsync` | `Result<byte[], Error>` | Binary content as byte array |
+
+## Request Configuration
+
+All methods have an overload accepting `Action<HttpRequestMessage>` for per-request customization such as adding headers, authentication, or correlation IDs:
+
+```csharp
+var result = await httpClient.GetResultAsync<Order>("/api/orders/123", request =>
+{
+    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    request.Headers.Add("X-Correlation-Id", correlationId);
+});
+```
+
+This works with all method types:
+
+```csharp
+// POST with auth
+var created = await httpClient.PostResultAsync<Order>("/api/orders", newOrder, request =>
+{
+    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+});
+
+// DELETE with auth
+var deleted = await httpClient.DeleteResultAsync("/api/orders/123", request =>
+{
+    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+});
+
+// Stream with auth
+var stream = await httpClient.GetStreamResultAsync("/api/exports/report.csv", request =>
+{
+    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+});
+
+// PATCH with ETag
+var patched = await httpClient.PatchResultAsync<Order>("/api/orders/123", patch, request =>
+{
+    request.Headers.Add("If-Match", etag);
+});
+```
+
+## Error Mapping
+
+Non-success HTTP status codes are automatically mapped to the most specific `Error` subtype:
+
+| Status Code | Error Type |
+|-------------|------------|
+| 400 Bad Request | `BadRequestError` |
+| 401 Unauthorized | `UnauthorizedError` |
+| 403 Forbidden | `ForbiddenError` |
+| 404 Not Found | `NotFoundError` |
+| 409 Conflict | `ConflictError` |
+| 422 Unprocessable Entity | `ValidationError` |
+| 5xx Server Error | `ExternalServiceError` |
+| Other | `HttpError` |
+
+Transport-level failures (network errors, DNS failures, timeouts) are captured as `HttpRequestError`.
+
+```csharp
+var result = await httpClient.GetResultAsync<Order>("/api/orders/123");
+
+result.TapError(error =>
+{
+    switch (error)
+    {
+        case NotFoundError:
+            logger.LogWarning("Order not found");
+            break;
+        case UnauthorizedError:
+            logger.LogWarning("Authentication required");
+            break;
+        case ExternalServiceError e:
+            logger.LogError("Server error: {Message}", e.Message);
+            break;
+        case HttpRequestError e:
+            logger.LogError("Network failure: {Type}", e.ExceptionType);
+            break;
+    }
+});
+```
+
+## Chaining with Map and Bind
+
+Results compose naturally with the core library's `Map` and `Bind`:
+
+```csharp
+// Transform the success value
+var orderId = await httpClient
+    .PostResultAsync<Order>("/api/orders", newOrder)
+    .Map(order => order.Id);
+
+// Chain dependent calls
+var invoice = await httpClient
+    .GetResultAsync<Order>("/api/orders/123")
+    .BindAsync(order =>
+        httpClient.GetResultAsync<Invoice>($"/api/invoices/{order.InvoiceId}"));
+```
+
+## Composition with Retry
+
+Wrap HTTP calls in a retry policy for transient failure handling:
+
+```csharp
+var result = await Retry
+    .WithMaxAttempts(3)
+    .WithBackoff(Backoff.Exponential(TimeSpan.FromMilliseconds(200)))
+    .WithRetryWhen(error => error is ExternalServiceError or HttpRequestError)
+    .OnRetry((attempt, error) =>
+        logger.LogWarning("Attempt {Attempt}: {Error}", attempt, error.Message))
+    .ExecuteAsync(() =>
+        httpClient.GetResultAsync<Data>("/api/data"));
+```
+
+## Composition with Circuit Breaker
+
+Protect against cascading failures from a consistently failing dependency:
+
+```csharp
+var breaker = CircuitBreaker
+    .WithFailureThreshold(5)
+    .WithResetTimeout(TimeSpan.FromSeconds(30))
+    .WithBreakWhen(error => error is ExternalServiceError or HttpRequestError);
+
+var result = await breaker.ExecuteAsync(
+    () => httpClient.GetResultAsync<Data>("/api/data"));
+```
+
+## Composition with MemoizeResult
+
+Cache successful HTTP responses while allowing failed requests to be retried:
+
+```csharp
+var cachedGet = MemoizeResult.FuncAsync<string, UserProfile, Error>(
+    endpoint => httpClient.GetResultAsync<UserProfile>(endpoint),
+    opts => opts
+        .WithExpiration(TimeSpan.FromMinutes(5))
+        .WithMaxSize(1000));
+
+var profile = await cachedGet("/api/users/123");
+// First call: HTTP request, caches on success
+// Second call within 5 min: returns cached result
+// If first call failed: second call retries the HTTP request
+```
+
+## Full Resilience Stack
+
+Combine caching, circuit breaking, retry, and Http extensions for production-grade resilience:
+
+```csharp
+var breaker = CircuitBreaker
+    .WithFailureThreshold(5)
+    .WithResetTimeout(TimeSpan.FromSeconds(30))
+    .WithBreakWhen(error => error is ExternalServiceError or HttpRequestError)
+    .OnStateChange((from, to) =>
+        logger.LogWarning("Circuit: {From} -> {To}", from, to));
+
+var cachedFetch = MemoizeResult.FuncAsync<string, CatalogItem, Error>(
+    endpoint => Retry
+        .WithMaxAttempts(3)
+        .WithBackoff(Backoff.Exponential(
+            TimeSpan.FromMilliseconds(200),
+            maxDelay: TimeSpan.FromSeconds(5)))
+        .WithRetryWhen(error =>
+            error is ExternalServiceError or HttpRequestError or CircuitBreakerOpenError)
+        .OnRetry((attempt, error) =>
+            logger.LogWarning("Retry {Attempt}: {Error}", attempt, error.Message))
+        .ExecuteAsync(() =>
+            breaker.ExecuteAsync(
+                () => httpClient.GetResultAsync<CatalogItem>(endpoint))),
+    opts => opts
+        .WithExpiration(TimeSpan.FromMinutes(10))
+        .WithMaxSize(500));
+
+// Usage
+var result = await cachedFetch("/api/catalog/item-42");
+```
+
+**Request flow:** Cache check → Retry loop → Circuit breaker → HTTP call
+
+On success, the result is cached. On transient failure, the retry policy backs off and retries. If the dependency is consistently failing, the circuit opens and subsequent calls are rejected immediately until the reset timeout elapses.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -12,6 +12,10 @@
   href: retry.md
 - name: Memoize
   href: memoize.md
+- name: Circuit Breaker
+  href: circuit-breaker.md
+- name: Http
+  href: http.md
 - name: Orchestration
   href: orchestration.md
 - name: "Example: Minimal Web API"

--- a/src/DarkPeak.Functional/CircuitBreaker.cs
+++ b/src/DarkPeak.Functional/CircuitBreaker.cs
@@ -1,0 +1,281 @@
+namespace DarkPeak.Functional;
+
+/// <summary>
+/// Represents the state of a circuit breaker.
+/// </summary>
+public enum CircuitBreakerState
+{
+    /// <summary>
+    /// Requests flow through normally. Failures are counted toward the threshold.
+    /// </summary>
+    Closed,
+
+    /// <summary>
+    /// Requests are immediately rejected. The circuit waits for the reset timeout before
+    /// transitioning to <see cref="HalfOpen"/>.
+    /// </summary>
+    Open,
+
+    /// <summary>
+    /// A single probe request is allowed through. Success transitions to <see cref="Closed"/>,
+    /// failure transitions back to <see cref="Open"/>.
+    /// </summary>
+    HalfOpen
+}
+
+/// <summary>
+/// Error returned when a circuit breaker is in the <see cref="CircuitBreakerState.Open"/> state
+/// and rejects a request without executing it.
+/// </summary>
+public sealed record CircuitBreakerOpenError : Error
+{
+    /// <summary>
+    /// Gets or sets the time remaining until the circuit breaker transitions to half-open.
+    /// </summary>
+    public TimeSpan? RetryAfter { get; init; }
+}
+
+/// <summary>
+/// Immutable circuit breaker policy built via fluent API.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The circuit breaker prevents cascading failures by short-circuiting requests to a failing
+/// dependency. It tracks consecutive failures and transitions between three states:
+/// </para>
+/// <list type="bullet">
+///   <item><term>Closed</term><description>Normal operation. Failures increment a counter. When the counter reaches the failure threshold, the circuit opens.</description></item>
+///   <item><term>Open</term><description>All requests are immediately rejected with <see cref="CircuitBreakerOpenError"/>. After the reset timeout, the circuit transitions to half-open.</description></item>
+///   <item><term>HalfOpen</term><description>One probe request is allowed through. On success the circuit closes; on failure it reopens.</description></item>
+/// </list>
+/// <para>
+/// The policy configuration is immutable. Internal state (failure count, current state, timestamps)
+/// is managed by a shared <see cref="CircuitBreakerStateTracker"/> allocated when the policy is created.
+/// Multiple calls to <see cref="Execute{T,TError}"/> and <see cref="ExecuteAsync{T,TError}"/> share
+/// this state, making the policy instance safe to reuse across threads.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var breaker = CircuitBreaker
+///     .WithFailureThreshold(5)
+///     .WithResetTimeout(TimeSpan.FromSeconds(30))
+///     .WithBreakWhen(error => error is ExternalServiceError)
+///     .OnStateChange((from, to) =>
+///         logger.LogWarning("Circuit breaker: {From} -> {To}", from, to));
+///
+/// var result = await breaker.ExecuteAsync(
+///     () => httpClient.GetResultAsync&lt;Data&gt;("/api/data"));
+/// </code>
+/// </example>
+public sealed record CircuitBreakerPolicy
+{
+    internal int FailureThreshold { get; init; } = 5;
+    internal TimeSpan ResetTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    internal Func<Error, bool>? BreakPredicate { get; init; }
+    internal Action<CircuitBreakerState, CircuitBreakerState>? OnStateChangeCallback { get; init; }
+    internal CircuitBreakerStateTracker StateTracker { get; init; } = new();
+
+    /// <summary>
+    /// Sets the duration the circuit stays open before transitioning to half-open.
+    /// </summary>
+    /// <param name="timeout">The reset timeout duration.</param>
+    public CircuitBreakerPolicy WithResetTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Must be greater than zero.");
+
+        return this with { ResetTimeout = timeout };
+    }
+
+    /// <summary>
+    /// Sets a predicate to determine which errors count toward the failure threshold.
+    /// If not set, all errors count as failures.
+    /// </summary>
+    /// <param name="predicate">A function that returns true for errors that should trip the breaker.</param>
+    public CircuitBreakerPolicy WithBreakWhen(Func<Error, bool> predicate) =>
+        this with { BreakPredicate = predicate };
+
+    /// <summary>
+    /// Sets a callback invoked when the circuit breaker changes state, for logging or observability.
+    /// </summary>
+    /// <param name="callback">A function receiving the previous and new state.</param>
+    public CircuitBreakerPolicy OnStateChange(Action<CircuitBreakerState, CircuitBreakerState> callback) =>
+        this with { OnStateChangeCallback = callback };
+
+    /// <summary>
+    /// Executes a function through the circuit breaker.
+    /// Returns the function's result if the circuit is closed or half-open,
+    /// or a <see cref="CircuitBreakerOpenError"/> if the circuit is open.
+    /// </summary>
+    public Result<T, TError> Execute<T, TError>(Func<Result<T, TError>> func) where TError : Error
+    {
+        var (state, retryAfter) = GetEffectiveState();
+
+        if (state == CircuitBreakerState.Open)
+        {
+            return Result.Failure<T, TError>((TError)(Error)new CircuitBreakerOpenError
+            {
+                Message = "Circuit breaker is open. Requests are being rejected.",
+                RetryAfter = retryAfter
+            });
+        }
+
+        var result = func();
+
+        if (result.IsSuccess)
+        {
+            OnSuccess();
+        }
+        else
+        {
+            var error = result.Match<TError>(
+                success: _ => throw new InvalidOperationException("Unexpected success"),
+                failure: e => e);
+
+            OnFailure(error);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Executes an async function through the circuit breaker.
+    /// Returns the function's result if the circuit is closed or half-open,
+    /// or a <see cref="CircuitBreakerOpenError"/> if the circuit is open.
+    /// </summary>
+    public async Task<Result<T, TError>> ExecuteAsync<T, TError>(Func<Task<Result<T, TError>>> func)
+        where TError : Error
+    {
+        var (state, retryAfter) = GetEffectiveState();
+
+        if (state == CircuitBreakerState.Open)
+        {
+            return Result.Failure<T, TError>((TError)(Error)new CircuitBreakerOpenError
+            {
+                Message = "Circuit breaker is open. Requests are being rejected.",
+                RetryAfter = retryAfter
+            });
+        }
+
+        var result = await func();
+
+        if (result.IsSuccess)
+        {
+            OnSuccess();
+        }
+        else
+        {
+            var error = result.Match<TError>(
+                success: _ => throw new InvalidOperationException("Unexpected success"),
+                failure: e => e);
+
+            OnFailure(error);
+        }
+
+        return result;
+    }
+
+    private (CircuitBreakerState State, TimeSpan? RetryAfter) GetEffectiveState()
+    {
+        lock (StateTracker.Lock)
+        {
+            if (StateTracker.State == CircuitBreakerState.Open)
+            {
+                var elapsed = DateTimeOffset.UtcNow - StateTracker.LastFailureTime;
+                if (elapsed >= ResetTimeout)
+                {
+                    TransitionTo(CircuitBreakerState.HalfOpen);
+                    return (CircuitBreakerState.HalfOpen, null);
+                }
+
+                var retryAfter = ResetTimeout - elapsed;
+                return (CircuitBreakerState.Open, retryAfter > TimeSpan.Zero ? retryAfter : null);
+            }
+
+            return (StateTracker.State, null);
+        }
+    }
+
+    private void OnSuccess()
+    {
+        lock (StateTracker.Lock)
+        {
+            StateTracker.ConsecutiveFailures = 0;
+            if (StateTracker.State != CircuitBreakerState.Closed)
+            {
+                TransitionTo(CircuitBreakerState.Closed);
+            }
+        }
+    }
+
+    private void OnFailure(Error error)
+    {
+        if (BreakPredicate is not null && !BreakPredicate(error))
+            return;
+
+        lock (StateTracker.Lock)
+        {
+            StateTracker.ConsecutiveFailures++;
+            StateTracker.LastFailureTime = DateTimeOffset.UtcNow;
+
+            if (StateTracker.State == CircuitBreakerState.HalfOpen)
+            {
+                TransitionTo(CircuitBreakerState.Open);
+            }
+            else if (StateTracker.State == CircuitBreakerState.Closed &&
+                     StateTracker.ConsecutiveFailures >= FailureThreshold)
+            {
+                TransitionTo(CircuitBreakerState.Open);
+            }
+        }
+    }
+
+    private void TransitionTo(CircuitBreakerState newState)
+    {
+        var previousState = StateTracker.State;
+        StateTracker.State = newState;
+
+        if (newState == CircuitBreakerState.Closed)
+            StateTracker.ConsecutiveFailures = 0;
+
+        OnStateChangeCallback?.Invoke(previousState, newState);
+    }
+}
+
+/// <summary>
+/// Mutable state tracker for a circuit breaker, shared across all executions of a policy instance.
+/// Thread safety is ensured via the <see cref="Lock"/> object.
+/// </summary>
+internal sealed class CircuitBreakerStateTracker
+{
+    internal readonly Lock Lock = new();
+    internal CircuitBreakerState State = CircuitBreakerState.Closed;
+    internal int ConsecutiveFailures;
+    internal DateTimeOffset? LastFailureTime;
+}
+
+/// <summary>
+/// Entry point for building circuit breaker policies.
+/// </summary>
+/// <example>
+/// <code>
+/// var breaker = CircuitBreaker.WithFailureThreshold(3)
+///     .WithResetTimeout(TimeSpan.FromSeconds(60));
+/// </code>
+/// </example>
+public static class CircuitBreaker
+{
+    /// <summary>
+    /// Creates a circuit breaker policy with the specified failure threshold.
+    /// The circuit opens after this many consecutive failures.
+    /// </summary>
+    /// <param name="threshold">The number of consecutive failures before the circuit opens (must be at least 1).</param>
+    public static CircuitBreakerPolicy WithFailureThreshold(int threshold)
+    {
+        if (threshold < 1)
+            throw new ArgumentOutOfRangeException(nameof(threshold), "Must be at least 1.");
+
+        return new CircuitBreakerPolicy { FailureThreshold = threshold };
+    }
+}

--- a/src/DarkPeak.Functional/DarkPeak.Functional.csproj
+++ b/src/DarkPeak.Functional/DarkPeak.Functional.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <PackageId>DarkPeak.Functional</PackageId>
-    <Description>A functional programming library for .NET providing monadic types (Option, Result, Either, Validation) with railway-oriented programming, retry policies, and memoization.</Description>
-    <PackageTags>functional;monad;option;result;either;validation;railway;retry;memoize</PackageTags>
+    <Description>A functional programming library for .NET providing monadic types (Option, Result, Either, Validation) with railway-oriented programming, retry policies, circuit breaker, memoization, and MemoizeResult for caching successful results.</Description>
+    <PackageTags>functional;monad;option;result;either;validation;railway;retry;memoize;circuit-breaker;memoize-result</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/DarkPeak.Functional/MemoizeResult.cs
+++ b/src/DarkPeak.Functional/MemoizeResult.cs
@@ -1,0 +1,199 @@
+using System.Collections.Concurrent;
+
+namespace DarkPeak.Functional;
+
+/// <summary>
+/// Provides factory methods to create memoized versions of functions that return
+/// <see cref="Result{T, TError}"/>, caching only successful results.
+/// Failed results pass through uncached so subsequent calls retry the computation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="Memoize"/>, which caches any return value unconditionally,
+/// <see cref="MemoizeResult"/> inspects the <see cref="Result{T, TError}"/> and only
+/// stores the success value. This prevents caching transient failures — if a call fails,
+/// the next call will re-execute the function instead of returning the cached failure.
+/// </para>
+/// <para>
+/// This is particularly useful for HTTP calls, external service requests, and other operations
+/// where failures are often transient and should be retried on the next attempt.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Cache successful API responses for 5 minutes; failures are never cached
+/// var cachedFetch = MemoizeResult.FuncAsync&lt;string, AppConfig, Error&gt;(
+///     endpoint => httpClient.GetResultAsync&lt;AppConfig&gt;(endpoint),
+///     opts => opts.WithExpiration(TimeSpan.FromMinutes(5)));
+///
+/// var result = await cachedFetch("/api/config");
+/// // First call: fetches from API, caches on success
+/// // Second call within 5 min: returns cached success immediately
+/// // If first call failed: second call retries the API
+/// </code>
+/// </example>
+public static class MemoizeResult
+{
+    /// <summary>
+    /// Memoizes an async single-argument function that returns a <see cref="Result{T, TError}"/>,
+    /// caching only successful results. Failed results are not cached.
+    /// Concurrent calls for the same key share a single in-flight computation (thundering-herd protection).
+    /// </summary>
+    /// <typeparam name="TKey">The argument type (used as cache key).</typeparam>
+    /// <typeparam name="TValue">The success value type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
+    /// <param name="func">The function to memoize.</param>
+    /// <param name="configure">Optional configuration for TTL, max size, and distributed cache.</param>
+    /// <returns>A memoized version of the function that caches only successful results.</returns>
+    public static Func<TKey, Task<Result<TValue, TError>>> FuncAsync<TKey, TValue, TError>(
+        Func<TKey, Task<Result<TValue, TError>>> func,
+        Func<MemoizeOptions, MemoizeOptions>? configure = null)
+        where TKey : notnull
+        where TError : Error
+    {
+        if (configure is not null)
+        {
+            var options = configure(new MemoizeOptions());
+            var provider = options.CacheProvider as ICacheProvider<TKey, TValue>;
+            var cache = new MemoizeCache<TKey, TValue>(options, provider);
+            var inflight = new ConcurrentDictionary<TKey, Task<Result<TValue, TError>>>();
+
+            return async key =>
+            {
+                // Check cache first (sync L1 path)
+                var cached = cache.TryGet(key);
+                if (cached is Some<TValue> some)
+                    return Result.Success<TValue, TError>(some.Value);
+
+                // Thundering-herd protection: share a single in-flight task per key
+                var task = inflight.GetOrAdd(key, k => ExecuteAndCache(k, func, cache));
+                try
+                {
+                    return await task;
+                }
+                finally
+                {
+                    inflight.TryRemove(key, out _);
+                }
+            };
+        }
+        else
+        {
+            var cache = new ConcurrentDictionary<TKey, TValue>();
+            var inflight = new ConcurrentDictionary<TKey, Task<Result<TValue, TError>>>();
+
+            return async key =>
+            {
+                if (cache.TryGetValue(key, out var cached))
+                    return Result.Success<TValue, TError>(cached);
+
+                var task = inflight.GetOrAdd(key, k => ExecuteAndCacheSimple(k, func, cache));
+                try
+                {
+                    return await task;
+                }
+                finally
+                {
+                    inflight.TryRemove(key, out _);
+                }
+            };
+        }
+    }
+
+    /// <summary>
+    /// Memoizes a synchronous single-argument function that returns a <see cref="Result{T, TError}"/>,
+    /// caching only successful results. Failed results are not cached.
+    /// </summary>
+    /// <typeparam name="TKey">The argument type (used as cache key).</typeparam>
+    /// <typeparam name="TValue">The success value type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
+    /// <param name="func">The function to memoize.</param>
+    /// <param name="configure">Optional configuration for TTL, max size, and distributed cache.</param>
+    /// <returns>A memoized version of the function that caches only successful results.</returns>
+    public static Func<TKey, Result<TValue, TError>> Func<TKey, TValue, TError>(
+        Func<TKey, Result<TValue, TError>> func,
+        Func<MemoizeOptions, MemoizeOptions>? configure = null)
+        where TKey : notnull
+        where TError : Error
+    {
+        if (configure is not null)
+        {
+            var options = configure(new MemoizeOptions());
+            var provider = options.CacheProvider as ICacheProvider<TKey, TValue>;
+            var cache = new MemoizeCache<TKey, TValue>(options, provider);
+
+            return key =>
+            {
+                var cached = cache.TryGet(key);
+                if (cached is Some<TValue> some)
+                    return Result.Success<TValue, TError>(some.Value);
+
+                var result = func(key);
+                result.Match(
+                    success: value =>
+                    {
+                        cache.Add(key, value);
+                        return value;
+                    },
+                    failure: _ => default!);
+                return result;
+            };
+        }
+        else
+        {
+            var cache = new ConcurrentDictionary<TKey, TValue>();
+
+            return key =>
+            {
+                if (cache.TryGetValue(key, out var cached))
+                    return Result.Success<TValue, TError>(cached);
+
+                var result = func(key);
+                result.Match(
+                    success: value =>
+                    {
+                        cache.TryAdd(key, value);
+                        return value;
+                    },
+                    failure: _ => default!);
+                return result;
+            };
+        }
+    }
+
+    private static async Task<Result<TValue, TError>> ExecuteAndCache<TKey, TValue, TError>(
+        TKey key,
+        Func<TKey, Task<Result<TValue, TError>>> func,
+        MemoizeCache<TKey, TValue> cache)
+        where TKey : notnull
+        where TError : Error
+    {
+        var result = await func(key);
+        result.Match(
+            success: value =>
+            {
+                cache.Add(key, value);
+                return value;
+            },
+            failure: _ => default!);
+        return result;
+    }
+
+    private static async Task<Result<TValue, TError>> ExecuteAndCacheSimple<TKey, TValue, TError>(
+        TKey key,
+        Func<TKey, Task<Result<TValue, TError>>> func,
+        ConcurrentDictionary<TKey, TValue> cache)
+        where TKey : notnull
+        where TError : Error
+    {
+        var result = await func(key);
+        result.Match(
+            success: value =>
+            {
+                cache.TryAdd(key, value);
+                return value;
+            },
+            failure: _ => default!);
+        return result;
+    }
+}

--- a/src/DarkPeak.Functional/Unit.cs
+++ b/src/DarkPeak.Functional/Unit.cs
@@ -1,14 +1,14 @@
-namespace DarkPeak.Functional.Http;
+namespace DarkPeak.Functional;
 
 /// <summary>
-/// Represents a valueless success type for HTTP operations that do not return a response body.
-/// Used as the success type parameter in <see cref="Result{T, TError}"/> when the operation
-/// succeeds but produces no meaningful value (e.g. DELETE, HEAD requests).
+/// Represents a valueless type that can be used as a generic type parameter where <c>void</c> cannot.
+/// Used as the success type in <see cref="Result{T, TError}"/> when an operation succeeds but
+/// produces no meaningful value (e.g. DELETE, fire-and-forget commands).
 /// </summary>
 /// <remarks>
 /// <para>
 /// <see cref="Unit"/> serves the same purpose as <c>void</c> but can be used as a type parameter,
-/// which <c>void</c> cannot. This allows DELETE and other bodyless operations to return
+/// which <c>void</c> cannot. This allows bodyless operations to return
 /// <c>Result&lt;Unit, Error&gt;</c> instead of requiring a separate non-generic Result type.
 /// </para>
 /// </remarks>

--- a/tests/DarkPeak.Functional.Tests/CircuitBreakerShould.cs
+++ b/tests/DarkPeak.Functional.Tests/CircuitBreakerShould.cs
@@ -1,0 +1,332 @@
+using DarkPeak.Functional;
+
+namespace DarkPeak.Functional.Tests;
+
+public class CircuitBreakerShould
+{
+    #region Execute (sync)
+
+    [Test]
+    public async Task Execute_returns_success_when_circuit_is_closed()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(3);
+
+        var result = breaker.Execute(() => Result.Success<int, Error>(42));
+
+        await Assert.That(result.IsSuccess).IsTrue();
+        await Assert.That(result.GetValueOrThrow()).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Execute_returns_failure_and_counts_toward_threshold()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(3);
+
+        var result = breaker.Execute(
+            () => Result.Failure<int, Error>(new ExternalServiceError { Message = "fail" }));
+
+        await Assert.That(result.IsFailure).IsTrue();
+        var error = result.Match(_ => null!, e => e);
+        await Assert.That(error).IsAssignableTo<ExternalServiceError>();
+    }
+
+    [Test]
+    public async Task Execute_opens_circuit_after_failure_threshold()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(3)
+            .WithResetTimeout(TimeSpan.FromSeconds(60));
+
+        for (var i = 0; i < 3; i++)
+        {
+            breaker.Execute(
+                () => Result.Failure<int, Error>(new ExternalServiceError { Message = $"fail {i}" }));
+        }
+
+        var result = breaker.Execute(() => Result.Success<int, Error>(42));
+
+        await Assert.That(result.IsFailure).IsTrue();
+        var error = result.Match(_ => null!, e => e);
+        await Assert.That(error).IsAssignableTo<CircuitBreakerOpenError>();
+    }
+
+    [Test]
+    public async Task Execute_resets_failure_count_on_success()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(3);
+
+        breaker.Execute(() => Result.Failure<int, Error>(new ExternalServiceError { Message = "fail 1" }));
+        breaker.Execute(() => Result.Failure<int, Error>(new ExternalServiceError { Message = "fail 2" }));
+        breaker.Execute(() => Result.Success<int, Error>(42));
+
+        // Should not be open because success reset the counter
+        var result = breaker.Execute(() => Result.Success<int, Error>(99));
+        await Assert.That(result.IsSuccess).IsTrue();
+        await Assert.That(result.GetValueOrThrow()).IsEqualTo(99);
+    }
+
+    [Test]
+    public async Task Execute_respects_break_predicate()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(2)
+            .WithResetTimeout(TimeSpan.FromSeconds(60))
+            .WithBreakWhen(error => error is ExternalServiceError);
+
+        // These failures don't match the predicate — should not trip
+        for (var i = 0; i < 5; i++)
+        {
+            breaker.Execute(
+                () => Result.Failure<int, Error>(new NotFoundError { Message = "not found" }));
+        }
+
+        var result = breaker.Execute(() => Result.Success<int, Error>(42));
+        await Assert.That(result.IsSuccess).IsTrue();
+    }
+
+    [Test]
+    public async Task Execute_trips_only_on_matching_predicate_errors()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(2)
+            .WithResetTimeout(TimeSpan.FromSeconds(60))
+            .WithBreakWhen(error => error is ExternalServiceError);
+
+        breaker.Execute(() => Result.Failure<int, Error>(new ExternalServiceError { Message = "fail 1" }));
+        breaker.Execute(() => Result.Failure<int, Error>(new ExternalServiceError { Message = "fail 2" }));
+
+        var result = breaker.Execute(() => Result.Success<int, Error>(42));
+        await Assert.That(result.IsFailure).IsTrue();
+        var error = result.Match(_ => null!, e => e);
+        await Assert.That(error).IsAssignableTo<CircuitBreakerOpenError>();
+    }
+
+    #endregion
+
+    #region ExecuteAsync
+
+    [Test]
+    public async Task ExecuteAsync_returns_success_when_circuit_is_closed()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(3);
+
+        var result = await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Success<int, Error>(42)));
+
+        await Assert.That(result.IsSuccess).IsTrue();
+        await Assert.That(result.GetValueOrThrow()).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_opens_circuit_after_failure_threshold()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(2)
+            .WithResetTimeout(TimeSpan.FromSeconds(60));
+
+        for (var i = 0; i < 2; i++)
+        {
+            await breaker.ExecuteAsync(
+                () => Task.FromResult(Result.Failure<int, Error>(
+                    new ExternalServiceError { Message = $"fail {i}" })));
+        }
+
+        var result = await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Success<int, Error>(42)));
+
+        await Assert.That(result.IsFailure).IsTrue();
+        var error = result.Match(_ => null!, e => e);
+        await Assert.That(error).IsAssignableTo<CircuitBreakerOpenError>();
+    }
+
+    [Test]
+    public async Task ExecuteAsync_resets_failure_count_on_success()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(3);
+
+        await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Failure<int, Error>(
+                new ExternalServiceError { Message = "fail" })));
+        await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Success<int, Error>(42)));
+
+        // Counter should be reset — two more failures should not trip
+        await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Failure<int, Error>(
+                new ExternalServiceError { Message = "fail" })));
+        await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Failure<int, Error>(
+                new ExternalServiceError { Message = "fail" })));
+
+        var result = await breaker.ExecuteAsync(
+            () => Task.FromResult(Result.Success<int, Error>(99)));
+        await Assert.That(result.IsSuccess).IsTrue();
+    }
+
+    #endregion
+
+    #region State Transitions
+
+    [Test]
+    public async Task Circuit_transitions_to_half_open_after_reset_timeout()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(1)
+            .WithResetTimeout(TimeSpan.FromMilliseconds(50));
+
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail" }));
+
+        // Circuit should be open
+        var openResult = breaker.Execute(() => Result.Success<int, Error>(42));
+        await Assert.That(openResult.IsFailure).IsTrue();
+
+        // Wait for reset timeout
+        await Task.Delay(100);
+
+        // Circuit should be half-open — allow one request through
+        var halfOpenResult = breaker.Execute(() => Result.Success<int, Error>(42));
+        await Assert.That(halfOpenResult.IsSuccess).IsTrue();
+        await Assert.That(halfOpenResult.GetValueOrThrow()).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Circuit_closes_on_success_in_half_open()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(1)
+            .WithResetTimeout(TimeSpan.FromMilliseconds(50));
+
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail" }));
+        await Task.Delay(100);
+
+        // Half-open: success should close
+        breaker.Execute(() => Result.Success<int, Error>(42));
+
+        // Should now be closed — multiple successes should work
+        var result1 = breaker.Execute(() => Result.Success<int, Error>(1));
+        var result2 = breaker.Execute(() => Result.Success<int, Error>(2));
+        await Assert.That(result1.IsSuccess).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+    }
+
+    [Test]
+    public async Task Circuit_reopens_on_failure_in_half_open()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(1)
+            .WithResetTimeout(TimeSpan.FromMilliseconds(50));
+
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail" }));
+        await Task.Delay(100);
+
+        // Half-open: failure should reopen
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail again" }));
+
+        // Should be open again
+        var result = breaker.Execute(() => Result.Success<int, Error>(42));
+        await Assert.That(result.IsFailure).IsTrue();
+        var error = result.Match(_ => null!, e => e);
+        await Assert.That(error).IsAssignableTo<CircuitBreakerOpenError>();
+    }
+
+    #endregion
+
+    #region OnStateChange Callback
+
+    [Test]
+    public async Task OnStateChange_is_invoked_on_transition_to_open()
+    {
+        var transitions = new List<(CircuitBreakerState From, CircuitBreakerState To)>();
+
+        var breaker = CircuitBreaker.WithFailureThreshold(2)
+            .WithResetTimeout(TimeSpan.FromSeconds(60))
+            .OnStateChange((from, to) => transitions.Add((from, to)));
+
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail 1" }));
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail 2" }));
+
+        await Assert.That(transitions).Count().IsEqualTo(1);
+        await Assert.That(transitions[0].From).IsEqualTo(CircuitBreakerState.Closed);
+        await Assert.That(transitions[0].To).IsEqualTo(CircuitBreakerState.Open);
+    }
+
+    [Test]
+    public async Task OnStateChange_is_invoked_through_full_cycle()
+    {
+        var transitions = new List<(CircuitBreakerState From, CircuitBreakerState To)>();
+
+        var breaker = CircuitBreaker.WithFailureThreshold(1)
+            .WithResetTimeout(TimeSpan.FromMilliseconds(50))
+            .OnStateChange((from, to) => transitions.Add((from, to)));
+
+        // Closed -> Open
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail" }));
+        await Task.Delay(100);
+
+        // Open -> HalfOpen -> Closed (on success in half-open)
+        breaker.Execute(() => Result.Success<int, Error>(42));
+
+        await Assert.That(transitions).Count().IsEqualTo(3);
+        await Assert.That(transitions[0]).IsEqualTo((CircuitBreakerState.Closed, CircuitBreakerState.Open));
+        await Assert.That(transitions[1]).IsEqualTo((CircuitBreakerState.Open, CircuitBreakerState.HalfOpen));
+        await Assert.That(transitions[2]).IsEqualTo((CircuitBreakerState.HalfOpen, CircuitBreakerState.Closed));
+    }
+
+    #endregion
+
+    #region CircuitBreakerOpenError
+
+    [Test]
+    public async Task CircuitBreakerOpenError_contains_retry_after()
+    {
+        var breaker = CircuitBreaker.WithFailureThreshold(1)
+            .WithResetTimeout(TimeSpan.FromSeconds(30));
+
+        breaker.Execute(() => Result.Failure<int, Error>(
+            new ExternalServiceError { Message = "fail" }));
+
+        var result = breaker.Execute(() => Result.Success<int, Error>(42));
+        var error = result.Match(_ => null!, e => e);
+        await Assert.That(error).IsAssignableTo<CircuitBreakerOpenError>();
+
+        var cbError = (CircuitBreakerOpenError)error;
+        await Assert.That(cbError.RetryAfter).IsNotNull();
+        await Assert.That(cbError.RetryAfter!.Value).IsGreaterThan(TimeSpan.Zero);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Test]
+    public async Task WithFailureThreshold_throws_on_zero()
+    {
+        await Assert.That(() => CircuitBreaker.WithFailureThreshold(0))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithFailureThreshold_throws_on_negative()
+    {
+        await Assert.That(() => CircuitBreaker.WithFailureThreshold(-1))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithResetTimeout_throws_on_zero()
+    {
+        await Assert.That(() => CircuitBreaker.WithFailureThreshold(3)
+            .WithResetTimeout(TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithResetTimeout_throws_on_negative()
+    {
+        await Assert.That(() => CircuitBreaker.WithFailureThreshold(3)
+            .WithResetTimeout(TimeSpan.FromSeconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    #endregion
+}

--- a/tests/DarkPeak.Functional.Tests/MemoizeResultShould.cs
+++ b/tests/DarkPeak.Functional.Tests/MemoizeResultShould.cs
@@ -1,0 +1,262 @@
+using DarkPeak.Functional;
+
+namespace DarkPeak.Functional.Tests;
+
+public class MemoizeResultShould
+{
+    #region FuncAsync (no options)
+
+    [Test]
+    public async Task FuncAsync_caches_successful_result()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<string, int, Error>(async key =>
+        {
+            callCount++;
+            return Result.Success<int, Error>(42);
+        });
+
+        var result1 = await cached("key");
+        var result2 = await cached("key");
+
+        await Assert.That(result1.IsSuccess).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(result1.GetValueOrThrow()).IsEqualTo(42);
+        await Assert.That(callCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task FuncAsync_does_not_cache_failed_result()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<string, int, Error>(async key =>
+        {
+            callCount++;
+            return callCount == 1
+                ? Result.Failure<int, Error>(new ExternalServiceError { Message = "fail" })
+                : Result.Success<int, Error>(42);
+        });
+
+        var result1 = await cached("key");
+        var result2 = await cached("key");
+
+        await Assert.That(result1.IsFailure).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(result2.GetValueOrThrow()).IsEqualTo(42);
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task FuncAsync_caches_per_key()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<string, int, Error>(async key =>
+        {
+            callCount++;
+            return Result.Success<int, Error>(key.Length);
+        });
+
+        var result1 = await cached("abc");
+        var result2 = await cached("abcdef");
+        var result3 = await cached("abc");
+
+        await Assert.That(result1.GetValueOrThrow()).IsEqualTo(3);
+        await Assert.That(result2.GetValueOrThrow()).IsEqualTo(6);
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region FuncAsync (with options)
+
+    [Test]
+    public async Task FuncAsync_with_ttl_caches_successful_result()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<string, int, Error>(
+            async key =>
+            {
+                callCount++;
+                return Result.Success<int, Error>(42);
+            },
+            opts => opts.WithExpiration(TimeSpan.FromMinutes(5)));
+
+        var result1 = await cached("key");
+        var result2 = await cached("key");
+
+        await Assert.That(result1.IsSuccess).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(callCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task FuncAsync_with_ttl_does_not_cache_failure()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<string, int, Error>(
+            async key =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? Result.Failure<int, Error>(new ExternalServiceError { Message = "fail" })
+                    : Result.Success<int, Error>(99);
+            },
+            opts => opts.WithExpiration(TimeSpan.FromMinutes(5)));
+
+        var result1 = await cached("key");
+        var result2 = await cached("key");
+
+        await Assert.That(result1.IsFailure).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(result2.GetValueOrThrow()).IsEqualTo(99);
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task FuncAsync_with_ttl_expires_cached_success()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<string, int, Error>(
+            async key =>
+            {
+                callCount++;
+                return Result.Success<int, Error>(callCount * 10);
+            },
+            opts => opts.WithExpiration(TimeSpan.FromMilliseconds(50)));
+
+        var result1 = await cached("key");
+        await Assert.That(result1.GetValueOrThrow()).IsEqualTo(10);
+
+        await Task.Delay(100);
+
+        var result2 = await cached("key");
+        await Assert.That(result2.GetValueOrThrow()).IsEqualTo(20);
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task FuncAsync_with_max_size_evicts_lru()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.FuncAsync<int, string, Error>(
+            async key =>
+            {
+                callCount++;
+                return Result.Success<string, Error>($"value-{key}");
+            },
+            opts => opts.WithMaxSize(2));
+
+        await cached(1);
+        await cached(2);
+        await cached(3); // evicts key 1
+
+        callCount = 0;
+
+        await cached(2); // cache hit
+        await cached(3); // cache hit
+        await cached(1); // cache miss, recomputed
+
+        await Assert.That(callCount).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Func (sync, no options)
+
+    [Test]
+    public async Task Func_caches_successful_result()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.Func<string, int, Error>(key =>
+        {
+            callCount++;
+            return Result.Success<int, Error>(42);
+        });
+
+        var result1 = cached("key");
+        var result2 = cached("key");
+
+        await Assert.That(result1.IsSuccess).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(callCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Func_does_not_cache_failed_result()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.Func<string, int, Error>(key =>
+        {
+            callCount++;
+            return callCount == 1
+                ? Result.Failure<int, Error>(new NotFoundError { Message = "not found" })
+                : Result.Success<int, Error>(42);
+        });
+
+        var result1 = cached("key");
+        var result2 = cached("key");
+
+        await Assert.That(result1.IsFailure).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region Func (sync, with options)
+
+    [Test]
+    public async Task Func_with_ttl_caches_successful_result()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.Func<string, int, Error>(
+            key =>
+            {
+                callCount++;
+                return Result.Success<int, Error>(42);
+            },
+            opts => opts.WithExpiration(TimeSpan.FromMinutes(5)));
+
+        var result1 = cached("key");
+        var result2 = cached("key");
+
+        await Assert.That(result1.IsSuccess).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(callCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Func_with_ttl_does_not_cache_failure()
+    {
+        var callCount = 0;
+
+        var cached = MemoizeResult.Func<string, int, Error>(
+            key =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? Result.Failure<int, Error>(new ExternalServiceError { Message = "fail" })
+                    : Result.Success<int, Error>(99);
+            },
+            opts => opts.WithExpiration(TimeSpan.FromMinutes(5)));
+
+        var result1 = cached("key");
+        var result2 = cached("key");
+
+        await Assert.That(result1.IsFailure).IsTrue();
+        await Assert.That(result2.IsSuccess).IsTrue();
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    #endregion
+}

--- a/tests/DarkPeak.Functional.Tests/UnitShould.cs
+++ b/tests/DarkPeak.Functional.Tests/UnitShould.cs
@@ -1,0 +1,49 @@
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace DarkPeak.Functional.Tests;
+
+/// <summary>
+/// Tests for <see cref="Unit"/> covering equality, default value, and type parameter usage.
+/// </summary>
+public class UnitShould
+{
+    [Test]
+    public async Task Unit_value_is_default()
+    {
+        var unit = Unit.Value;
+
+        await Assert.That(unit).IsEqualTo(default(Unit));
+    }
+
+    [Test]
+    public async Task Unit_values_are_equal()
+    {
+        var unit1 = Unit.Value;
+        var unit2 = Unit.Value;
+
+        await Assert.That(unit1).IsEqualTo(unit2);
+    }
+
+    [Test]
+    public async Task Unit_can_be_used_as_result_success_type()
+    {
+        var result = Result.Success<Unit, Error>(Unit.Value);
+
+        await Assert.That(result.IsSuccess).IsTrue();
+        var value = result.Match(v => v, _ => default);
+        await Assert.That(value).IsEqualTo(Unit.Value);
+    }
+
+    [Test]
+    public async Task Unit_result_failure_propagates_error()
+    {
+        var error = new InternalError { Message = "Something failed" };
+        var result = Result.Failure<Unit, Error>(error);
+
+        await Assert.That(result.IsFailure).IsTrue();
+        var err = result.Match(_ => null!, e => e);
+        await Assert.That(err.Message).IsEqualTo("Something failed");
+    }
+}


### PR DESCRIPTION
## Summary

- **Circuit Breaker** — New `CircuitBreakerPolicy` with fluent builder API tracking consecutive failures across Closed/Open/HalfOpen states, configurable failure threshold and reset timeout, selective breaking via `WithBreakWhen`, and `OnStateChange` observability callback. Thread-safe via `Lock`-protected shared state tracker.
- **MemoizeResult** — New helper that memoizes `Result<T, TError>`-returning functions, caching only successful results. Failed results pass through uncached so subsequent calls retry the computation. Supports TTL, LRU, and distributed cache providers.
- **Move Unit to core** — `Unit` moved from `DarkPeak.Functional.Http` to `DarkPeak.Functional` namespace so it can be used across all packages.
- **Non-JSON response types** — Added `GetStringResultAsync`, `GetStreamResultAsync` (with `ResponseHeadersRead`), and `GetBytesResultAsync` to `HttpClientExtensions`.
- **Request configuration overloads** — Added `Action<HttpRequestMessage> configure` overloads for all HTTP methods (GET, POST, PUT, PATCH, DELETE) and non-JSON GET methods for per-request header/auth customization.
- **Documentation** — New `circuit-breaker.md` and `http.md` docs pages; updated `retry.md` to use Http extensions; updated TOC, README, copilot-instructions, and PackageTags.

## Tests

49 new tests added (19 CircuitBreaker, 11 MemoizeResult, 9 non-JSON responses, 10 configure overloads). All **487 tests pass** across 3 projects.

## Breaking Changes

- `Unit` moved from `DarkPeak.Functional.Http` to `DarkPeak.Functional` namespace (no `TypeForwardedTo`). Consumers using `Unit` directly will need to update their `using` statements.