### PR TITLE
docs: add Dapper and EntityFramework to README and update docs index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A functional programming library for .NET providing monadic types and railway-or
 | **DarkPeak.Functional.Http** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.Http.svg)](https://www.nuget.org/packages/DarkPeak.Functional.Http/) | Wraps `HttpClient` operations in `Result<T, Error>` for type-safe, exception-free HTTP communication. Supports JSON, string, stream, and byte array responses with per-request header customization. |
 | **DarkPeak.Functional.AspNet** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.AspNet.svg)](https://www.nuget.org/packages/DarkPeak.Functional.AspNet/) | ASP.NET integration that converts `Result<T, Error>` to `IResult` and `ProblemDetails` for idiomatic minimal API error handling. |
 | **DarkPeak.Functional.Redis** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.Redis.svg)](https://www.nuget.org/packages/DarkPeak.Functional.Redis/) | Redis distributed cache provider implementing `ICacheProvider<TKey, TValue>` for use with `Memoize` and `MemoizeResult`. |
+| **DarkPeak.Functional.Dapper** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.Dapper.svg)](https://www.nuget.org/packages/DarkPeak.Functional.Dapper/) | Wraps Dapper queries and commands in `Result<T, Error>` with typed `DatabaseError` mapping and transaction support. |
+| **DarkPeak.Functional.EntityFramework** | [![NuGet](https://img.shields.io/nuget/v/DarkPeak.Functional.EntityFramework.svg)](https://www.nuget.org/packages/DarkPeak.Functional.EntityFramework/) | Wraps EF Core operations in `Result<T, Error>` with typed errors for concurrency, save failures, and general database exceptions. |
 
 All types support `Map`, `Bind`, `Match`, LINQ query syntax, and async variants.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,26 @@
 
 A functional programming library for .NET providing monadic types and railway-oriented programming patterns.
 
-## Features
+## Core Types
 
 - **[Option&lt;T&gt;](articles/option.md)** — Eliminates null reference exceptions with explicit presence/absence
 - **[Result&lt;T, TError&gt;](articles/result.md)** — Railway-oriented error handling without exceptions
 - **[Either&lt;TLeft, TRight&gt;](articles/either.md)** — Symmetric dual-value type for branching logic
 - **[Validation&lt;T, TError&gt;](articles/validation.md)** — Accumulates multiple errors instead of short-circuiting
+
+## Resilience & Caching
+
 - **[Retry](articles/retry.md)** — Configurable retry policies with backoff strategies
+- **[Circuit Breaker](articles/circuit-breaker.md)** — Prevents cascading failures by short-circuiting requests to failing dependencies
 - **[Memoize](articles/memoize.md)** — Function caching with TTL, LRU eviction, and distributed cache support
+
+## Integration Packages
+
+- **[DarkPeak.Functional.Http](articles/http.md)** — Wraps `HttpClient` in `Result<T, Error>` for exception-free HTTP communication
+- **[DarkPeak.Functional.AspNet](articles/aspnet.md)** — Converts `Result<T, Error>` to `IResult` and `ProblemDetails` for minimal APIs
+- **[DarkPeak.Functional.Redis](articles/redis.md)** — Redis distributed cache provider for `Memoize` and `MemoizeResult`
+- **[DarkPeak.Functional.Dapper](articles/dapper.md)** — Wraps Dapper queries and commands in `Result<T, Error>` with typed database error mapping
+- **[DarkPeak.Functional.EntityFramework](articles/entity-framework.md)** — Wraps EF Core operations in `Result<T, Error>` with typed error handling
 
 ## Quick Start
 
@@ -43,4 +55,6 @@ dotnet add package DarkPeak.Functional
 ## Learn More
 
 - [Getting Started](articles/getting-started.md) — Installation, concepts, and first steps
+- [Orchestration](articles/orchestration.md) — Combining Validation and Result pipelines in real-world scenarios
+- [Example: Blazor Form](articles/example-blazor-form.md) — Using Validation in a Blazor component with inline field errors
 - [API Reference](api/index.md) — Full API documentation generated from source


### PR DESCRIPTION
## Summary

- Add **DarkPeak.Functional.Dapper** and **DarkPeak.Functional.EntityFramework** to the README packages table with NuGet badges
- Restructure `docs/index.md` into Core Types, Resilience & Caching, and Integration Packages sections
- Add missing Circuit Breaker entry and all five integration packages to the docs index
- Link Orchestration guide and Blazor Form example from the Learn More section