### PR TITLE
docs: add HealthChecks and Mediator links to docs index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ A functional programming library for .NET providing monadic types and railway-or
 - **[DarkPeak.Functional.Redis](articles/redis.md)** — Redis distributed cache provider for `Memoize` and `MemoizeResult`
 - **[DarkPeak.Functional.Dapper](articles/dapper.md)** — Wraps Dapper queries and commands in `Result<T, Error>` with typed database error mapping
 - **[DarkPeak.Functional.EntityFramework](articles/entity-framework.md)** — Wraps EF Core operations in `Result<T, Error>` with typed error handling
+- **[DarkPeak.Functional.HealthChecks](articles/health-checks.md)** — Exposes circuit breaker and cache provider status via ASP.NET Core `IHealthCheck` implementations
+- **[DarkPeak.Functional.Mediator](articles/mediator.md)** — Integrates `Result<T, Error>` with [Mediator](https://github.com/martinothamar/Mediator) for source-generated CQRS pipelines
 
 ## Quick Start
 


### PR DESCRIPTION
The recent additions of `DarkPeak.Functional.HealthChecks` and `DarkPeak.Functional.Mediator` included guide articles and `toc.yml` entries, but the main docs landing page (`docs/index.md`) wasn't updated with links to them.

This PR adds both packages to the **Integration Packages** section of the docs index page.